### PR TITLE
Fix escaping

### DIFF
--- a/blogml-importer.php
+++ b/blogml-importer.php
@@ -332,6 +332,9 @@ class BlogML_Import {
 		}
 		$post_content = $wpdb->escape(str_replace(array ('<![CDATA[', ']]>'), '',$post_content));
 		
+        // Added to convert ampersand codes to their ascii equivalents so HTML is imported as-is
+        $post_content = htmlentities($post_content);
+        
 		$categories = array ();
 		$cat_results = $this->xPath->match("categories/category", $post);
 		$cat_count = count($cat_results);

--- a/blogml-importer.php
+++ b/blogml-importer.php
@@ -339,6 +339,8 @@ class BlogML_Import {
 		$cat_results = $this->xPath->match("categories/category", $post);
 		$cat_count = count($cat_results);
 		for ($cat_index = 0; $cat_index < $cat_count; $cat_index++) {
+            /* the data I'm looking at has ref being an identifier for a
+            list of categories defined at a higher level in the tree structure, so this isn't quite right. */
 			$categories[$cat_index] = $wpdb->escape($this->xPath->getAttributes($cat_results[$cat_index], 'ref'));
 		}
 

--- a/blogml-importer.php
+++ b/blogml-importer.php
@@ -333,7 +333,7 @@ class BlogML_Import {
 		$post_content = $wpdb->escape(str_replace(array ('<![CDATA[', ']]>'), '',$post_content));
 		
         // Added to convert ampersand codes to their ascii equivalents so HTML is imported as-is
-        $post_content = htmlentities($post_content);
+        $post_content = html_entity_decode($post_content);
         
 		$categories = array ();
 		$cat_results = $this->xPath->match("categories/category", $post);


### PR DESCRIPTION
Convert ampersand codes to HTML before loading into WordPress database to preserve content formatting